### PR TITLE
Add Docs CI

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to master branch</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./master/index.html">
+    <link rel="canonical" href="master/index.html">
+  </head>
+</html>

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,80 @@
+name: Docs CI
+
+on:
+  push:
+    branches:
+      # Add more branches here to publish docs from other branches
+      - master
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+# Global environment
+env:
+  # EPICS Base version for system block IOC
+  EPICS_BASE_VER: R3.14.12.7
+  EPICS_BASE_DIR: epics_base
+  EPCISDBBUILER_VERSION: 1.5
+
+jobs:
+  build:
+    name: "Docs CI"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        with:
+          # require history to get back to last tag for version number of branches
+          fetch-depth: 0
+          submodules: true
+
+      - name: Install Packages
+        run: |
+          sudo apt-get install python3-sphinx
+          pip install epicsdbbuilder==${EPCISDBBUILER_VERSION}
+
+      - name: Cache EPICS Base
+        uses: actions/cache@v2
+        id: epics-base-cache
+        with:
+          path: ${{ env.EPICS_BASE_DIR }}
+          key: epics_base-${{ runner.os }}-${{ env.EPICS_BASE_VER }}
+
+      - name: Install EPICS Base
+        if: steps.epics-base-cache.outputs.cache-hit != 'true'
+        run: |
+          wget -nv https://github.com/epics-base/epics-base/archive/${EPICS_BASE_VER}.tar.gz
+          tar -zxf ${EPICS_BASE_VER}.tar.gz
+          mv epics-base-${EPICS_BASE_VER} ${EPICS_BASE_DIR}
+          make -sj -C ${EPICS_BASE_DIR}/
+
+      - name: Set environment for future steps
+        # Override EPICS_BASE defined in config/RELEASE
+        # Override PYTHON defined in config/CONFIG_SITE
+        # Override EPICSDBBUILDER defined in config/CONFIG_SITE
+        run: |
+          echo "EPICS_BASE=`pwd`/${EPICS_BASE_DIR}" >> $GITHUB_ENV
+          echo "PYTHON=python" >> $GITHUB_ENV 
+          echo "EPICSDBBUILDER=${EPCISDBBUILER_VERSION}" >> $GITHUB_ENV 
+
+      - name: Build Docs
+        run: |
+          make
+          cd docs && make install
+
+      - name: Move to versioned directory
+        # e.g. master or 0.1.2
+        run: mv docs/html ".github/pages/${GITHUB_REF##*/}"
+
+      - name: Publish Docs to gh-pages
+        # Only master and tags are published
+        if: "${{ github.repository_owner == 'dls-controls' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}"
+        # We pin to the SHA, not the tag, for security reasons.
+        # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .github/pages
+          keep_files: true

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,13 @@ IOCs.  This framework is designed to be used in combination with the
 epicsdbbuilder library for building the database file, but can be used
 standalone.
 
+
+============== ==============================================================
+Source code    https://github.com/dls-controls/epics_device
+Documentation  https://dls-controls.github.io/epics_device
+============== ==============================================================
+
+
 Simple Example
 --------------
 
@@ -79,5 +86,7 @@ means that following two files in the ``configure`` directory must be edited:
         ``pkg_resources.require``.  Note that if an explicit path is given it is
         not necessary to install or setup ``epicsdbbuilder``, it can be used in
         place.
+
+See https://dls-controls.github.io/epics_device for more detailed documentation.
 
 ..  _epicsdbbuilder: https://github.com/Araneidae/epicsdbbuilder

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -16,8 +16,8 @@ CROSS_COMPILER_TARGET_ARCHS += linux-arm_elhf
 
 # This can either be an explicit path to the directory containing the
 # epicsdbbuilder module or a version number understood by pkg_resources.require
-EPICSDBBUILDER = 1.3
+EPICSDBBUILDER ?= 1.3
 
-PYTHON = dls-python
+PYTHON ?= dls-python
 
 # vim: set filetype=make:

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -22,4 +22,4 @@
 
 # EPICS_BASE usually appears last so other apps can override stuff.
 # Point this to the EPICS installation.
-EPICS_BASE = /dls_sw/epics/R3.14.12.7/base
+EPICS_BASE ?= /dls_sw/epics/R3.14.12.7/base


### PR DESCRIPTION
Add the documentation CI, which will publish the docs to https://dls-controls.github.io/epics_device

Note the docs aren't there yet as this has never run against the master branch.
