### PR TITLE
Update dependencies to Python3 compatible versions

### DIFF
--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -1,4 +1,4 @@
-name: Docs CI
+name: Build and Docs CI
 
 on:
   push:
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    name: "Docs CI"
+    name: "Build and Docs CI"
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +32,8 @@ jobs:
           submodules: true
 
       - name: Install Packages
+        # Pin Sphinx version to one that supports Python3, but does not feature an API
+        # change that would break our custom cdomain.py extension
         run: |
           pip install epicsdbbuilder==${EPCISDBBUILER_VERSION} sphinx==2.3.1
 
@@ -51,20 +53,27 @@ jobs:
           make -sj -C ${EPICS_BASE_DIR}/
 
       - name: Set environment for future steps (Overrides variables in config/CONFIG_SITE)
-        # Override EPICS_BASE defined in config/RELEASE
-        # Override PYTHON defined in config/CONFIG_SITE
-        # Override EPICSDBBUILDER defined in config/CONFIG_SITE
+        # Override various environment variables defined in CONFIG_SITE with values that
+        # work on CI. Delete the compiler targets as they don't actually build, they just
+        # silently pass despite doing nothing. Leaving them in place confuses the example
+        # IOC builds.
         run: |
           echo "EPICS_BASE=`pwd`/${EPICS_BASE_DIR}" >> $GITHUB_ENV
           echo "PYTHON=python" >> $GITHUB_ENV 
           echo "EPICSDBBUILDER=${EPCISDBBUILER_VERSION}" >> $GITHUB_ENV
           echo "SPHINXBUILD=${SPHINXBUILD_LOCATION}/sphinx-build" >> $GITHUB_ENV
+          sed -i '/CROSS_COMPILER_TARGET_ARCHS/d' configure/CONFIG_SITE
 
-      - name: Build Docs
+      - name: Build (including docs)
         run: |
           make
 
-      - name: Move to versioned directory
+      - name: Build Examples
+        run: |
+          make -C examples/example_ioc/
+          make -C examples/basic_ioc/
+
+      - name: Move Docs to versioned directory
         # e.g. master or 0.1.2
         run: mv docs/html ".github/pages/${GITHUB_REF##*/}"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ env:
   EPICS_BASE_VER: R3.14.12.7
   EPICS_BASE_DIR: epics_base
   EPCISDBBUILER_VERSION: 1.5
+  SPHINXBUILD_LOCATION: ~/.local/bin/
 
 jobs:
   build:
@@ -32,8 +33,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install python3-sphinx
-          pip install epicsdbbuilder==${EPCISDBBUILER_VERSION}
+          pip install epicsdbbuilder==${EPCISDBBUILER_VERSION} sphinx==2.3.1
 
       - name: Cache EPICS Base
         uses: actions/cache@v2
@@ -50,19 +50,19 @@ jobs:
           mv epics-base-${EPICS_BASE_VER} ${EPICS_BASE_DIR}
           make -sj -C ${EPICS_BASE_DIR}/
 
-      - name: Set environment for future steps
+      - name: Set environment for future steps (Overrides variables in config/CONFIG_SITE)
         # Override EPICS_BASE defined in config/RELEASE
         # Override PYTHON defined in config/CONFIG_SITE
         # Override EPICSDBBUILDER defined in config/CONFIG_SITE
         run: |
           echo "EPICS_BASE=`pwd`/${EPICS_BASE_DIR}" >> $GITHUB_ENV
           echo "PYTHON=python" >> $GITHUB_ENV 
-          echo "EPICSDBBUILDER=${EPCISDBBUILER_VERSION}" >> $GITHUB_ENV 
+          echo "EPICSDBBUILDER=${EPCISDBBUILER_VERSION}" >> $GITHUB_ENV
+          echo "SPHINXBUILD=${SPHINXBUILD_LOCATION}/sphinx-build" >> $GITHUB_ENV
 
       - name: Build Docs
         run: |
           make
-          cd docs && make install
 
       - name: Move to versioned directory
         # e.g. master or 0.1.2
@@ -73,7 +73,7 @@ jobs:
         if: "${{ github.repository_owner == 'dls-controls' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}"
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .github/pages

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -18,7 +18,7 @@ CROSS_COMPILER_TARGET_ARCHS += linux-arm_elhf
 # epicsdbbuilder module or a version number understood by pkg_resources.require
 EPICSDBBUILDER ?= /dls_sw/prod/python3/RHEL7-x86_64/epicsdbbuilder/1.5
 
-SPHINXBUILD ?= sphinx-build
+SPHINXBUILD ?= /dls_sw/prod/python3/RHEL7-x86_64/sphinx/2.3.1/prefix/bin/sphinx-build
 
 PYTHON ?= python3
 

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -16,8 +16,10 @@ CROSS_COMPILER_TARGET_ARCHS += linux-arm_elhf
 
 # This can either be an explicit path to the directory containing the
 # epicsdbbuilder module or a version number understood by pkg_resources.require
-EPICSDBBUILDER ?= 1.3
+EPICSDBBUILDER ?= /dls_sw/prod/python3/RHEL7-x86_64/epicsdbbuilder/1.5
 
-PYTHON ?= dls-python
+SPHINXBUILD ?= sphinx-build
+
+PYTHON ?= python3
 
 # vim: set filetype=make:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,12 +3,13 @@ TOP = ..
 export TOP
 
 include $(TOP)/configure/RELEASE
+include $(TOP)/configure/CONFIG_SITE
 export EPICS_BASE
 
 html: $(wildcard *.rst) $(wildcard *.py)
 
 install: html
-	sphinx-build -nE -b html . html
+	$(SPHINXBUILD) -nE -b html . html
 
 clean:
 	rm -rf html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,9 +7,9 @@ include $(TOP)/configure/CONFIG_SITE
 export EPICS_BASE
 
 html: $(wildcard *.rst) $(wildcard *.py)
+	$(SPHINXBUILD) -nE -b html . html
 
 install: html
-	$(SPHINXBUILD) -nE -b html . html
 
 clean:
 	rm -rf html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,8 +52,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'EPICS Device'
-copyright = u'2015, Michael Abbott'
+project = 'EPICS Device'
+copyright = '2015, Michael Abbott'
 
 # Use the Sphinx C domain for code documentation.
 primary_domain = 'c'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Cothread documentation build configuration file, created by
+# Epics Device documentation build configuration file.
+# Originally taken from Cothread configuration file, which was created by
 # sphinx-quickstart on Fri May 14 13:06:33 2010.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -36,7 +37,7 @@ extensions = [
     'cdomain',                  # Override sphinx C domain implementation
 ]
 
-viewcode_import = True
+viewcode_follow_imported_members = True
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/epics_device/common.py
+++ b/epics_device/common.py
@@ -26,7 +26,7 @@ def Trigger(prefix, *pvs, **kargs):
     if kargs.pop('set_time', False):
         trigger.TSE = -2
 
-    assert kargs == {}, 'Unexpected keyword args: %s' % kargs.keys()
+    assert kargs == {}, 'Unexpected keyword args: %s' % list(kargs.keys())
     return trigger
 
 

--- a/epics_device/device.py
+++ b/epics_device/device.py
@@ -26,8 +26,9 @@ class EpicsDevice:
 
             # Check for a description, make a report if none given.
             if 'DESC' not in fields:
-                print('No description for', \
-                    self.separator.join(self.address_prefix + [name]), file=sys.stderr)
+                print('No description for', 
+                    self.separator.join(self.address_prefix + [name]), 
+                    file=sys.stderr)
 
             return record
 

--- a/epics_device/device.py
+++ b/epics_device/device.py
@@ -1,5 +1,7 @@
 # Support code for Python epics database generation.
 
+from __future__ import print_function
+
 import sys
 import os
 
@@ -24,8 +26,8 @@ class EpicsDevice:
 
             # Check for a description, make a report if none given.
             if 'DESC' not in fields:
-                print >>sys.stderr, 'No description for', \
-                    self.separator.join(self.address_prefix + [name])
+                print('No description for', \
+                    self.separator.join(self.address_prefix + [name]), file=sys.stderr)
 
             return record
 

--- a/examples/basic_ioc/configure/CONFIG_SITE
+++ b/examples/basic_ioc/configure/CONFIG_SITE
@@ -13,4 +13,4 @@ STATIC_BUILD = YES
 CROSS_COMPILER_TARGET_ARCHS =
 
 # Identify which python interpreter to use.
-PYTHON = dls-python
+PYTHON ?= python3

--- a/examples/basic_ioc/configure/RELEASE
+++ b/examples/basic_ioc/configure/RELEASE
@@ -24,4 +24,4 @@ EPICS_DEVICE = $(TOP)/../..
 
 # EPICS_BASE usually appears last so other apps can override stuff.
 # Point this to the EPICS installation.
-EPICS_BASE = /dls_sw/epics/R3.14.12.7/base
+EPICS_BASE ?= /dls_sw/epics/R3.14.12.7/base

--- a/examples/example_ioc/configure/CONFIG_SITE
+++ b/examples/example_ioc/configure/CONFIG_SITE
@@ -10,7 +10,7 @@
 
 STATIC_BUILD = YES
 
-CROSS_COMPILER_TARGET_ARCHS = linux-arm_el
+CROSS_COMPILER_TARGET_ARCHS =
 
 # Identify which python interpreter to use.  Must be at least version 2.4.
-PYTHON = dls-python
+PYTHON ?= python3

--- a/examples/example_ioc/configure/RELEASE
+++ b/examples/example_ioc/configure/RELEASE
@@ -24,4 +24,4 @@ EPICS_DEVICE = $(TOP)/../..
 
 # EPICS_BASE usually appears last so other apps can override stuff.
 # Point this to the EPICS installation.
-EPICS_BASE = /dls_sw/epics/R3.14.12.7/base
+EPICS_BASE ?= /dls_sw/epics/R3.14.12.7/base


### PR DESCRIPTION
Currently this module has a dependency on [EPICSDBBUILDER](https://github.com/dls-controls/epicsdbbuilder) version 1.3. This version does not support Python3.

Updated to use a Python3 compatible version, and also swap the default Python executable to Python3.