### PR TITLE
Add dump_db utility method

### DIFF
--- a/docs/epics_device.rst
+++ b/docs/epics_device.rst
@@ -793,3 +793,13 @@ records.
     ========================================================================== =
 
     Reads the current waveform value of a waveform record.
+
+Utility Functions
+-----------------
+
+Documentation for miscellaenous auxiliary functions.
+
+..  function:: void dump_epics_device_db(FILE *output)
+
+    This prints all currently published entries in the database to the given
+    output object.

--- a/src/epics_device.c
+++ b/src/epics_device.c
@@ -1166,18 +1166,18 @@ DEFINE_DEVICE(mbbi,      5, read_mbbi);
 DEFINE_DEVICE(mbbo,      5, write_mbbo);
 DEFINE_DEVICE(waveform,  5, process_waveform);
 
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                          Utility Functions                                */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void dump_db(void)
+void dump_epics_device_db(FILE *output)
 {
     const void *key;
     void *value;
-    printf("Dumping database:\n");
     for (int ix = 0; hash_table_walk(hash_table, &ix, &key, &value);)
     {
         const struct epics_record *base = value;
-        printf("\t%s\n", base->key);
+        fprintf(output, "\t%s\n", base->key);
     }
 }

--- a/src/epics_device.c
+++ b/src/epics_device.c
@@ -1165,3 +1165,19 @@ DEFINE_DEVICE(stringout, 5, write_stringout);
 DEFINE_DEVICE(mbbi,      5, read_mbbi);
 DEFINE_DEVICE(mbbo,      5, write_mbbo);
 DEFINE_DEVICE(waveform,  5, process_waveform);
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                          Utility Functions                                */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void dump_db(void)
+{
+    const void *key;
+    void *value;
+    printf("Dumping database:\n");
+    for (int ix = 0; hash_table_walk(hash_table, &ix, &key, &value);)
+    {
+        const struct epics_record *base = value;
+        printf("\t%s\n", base->key);
+    }
+}

--- a/src/epics_device.h
+++ b/src/epics_device.h
@@ -338,6 +338,9 @@ bool format_epics_string(EPICS_STRING *s, const char *format, ...)
 /* This is the abstract interface returned by all core publish methods. */
 struct epics_record;
 
+/* Utility function to dump all currently published entries in the database */
+void dump_db(void);
+
 /* Makes the named record of the given type available for binding.  The
  * particular structure passed to args is determined by the record type, this
  * function should only ever be called via the PUBLISH() or PUBLISH_WAVEFORM()

--- a/src/epics_device.h
+++ b/src/epics_device.h
@@ -243,6 +243,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <pthread.h>    // Needed for pthread_mutex_t declaration
 
 struct timespec;
@@ -339,7 +340,7 @@ bool format_epics_string(EPICS_STRING *s, const char *format, ...)
 struct epics_record;
 
 /* Utility function to dump all currently published entries in the database */
-void dump_db(void);
+void dump_epics_device_db(FILE *output);
 
 /* Makes the named record of the given type available for binding.  The
  * particular structure passed to args is determined by the record type, this


### PR DESCRIPTION
There may want to be some tweaking to the exact format of printing, but before going overboard and trying to print a nicely formatted table I thought it should be discussed.

Current output looks like:

```
Dumping database:
    ai:record_one
    mbbi:record_three
```