### PR TITLE
Remove unnecessary question marks

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -16,10 +16,10 @@ CROSS_COMPILER_TARGET_ARCHS += linux-arm_elhf
 
 # This can either be an explicit path to the directory containing the
 # epicsdbbuilder module or a version number understood by pkg_resources.require
-EPICSDBBUILDER ?= /dls_sw/prod/python3/RHEL7-x86_64/epicsdbbuilder/1.5
+EPICSDBBUILDER = /dls_sw/prod/python3/RHEL7-x86_64/epicsdbbuilder/1.5
 
-SPHINXBUILD ?= /dls_sw/prod/python3/RHEL7-x86_64/sphinx/2.3.1/prefix/bin/sphinx-build
+SPHINXBUILD = /dls_sw/prod/python3/RHEL7-x86_64/sphinx/2.3.1/prefix/bin/sphinx-build
 
-PYTHON ?= python
+PYTHON = python
 
 # vim: set filetype=make:

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -22,4 +22,4 @@
 
 # EPICS_BASE usually appears last so other apps can override stuff.
 # Point this to the EPICS installation.
-EPICS_BASE ?= /dls_sw/epics/R3.14.12.7/base
+EPICS_BASE = /dls_sw/epics/R3.14.12.7/base


### PR DESCRIPTION
These were put it to allow various environment variable overrides in CI, but since then we've changed the mechanism to just directly write into the Makefiles as appropriate.
Keeping the question mark in configure/RELEASE causes the dls-release.py script to fail to correctly replace the value when we request an override (when specifying an EPICS version with -e)